### PR TITLE
feat: Add base Dockerfile and dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+target
+.dockerignore
+Dockerfile
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,6 +97,14 @@ jobs:
           prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Publish to Registry
+        uses: elgohr/Publish-Docker-Github-Action@master
+        with:
+          name: bytesonus/juno
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          tags: "latest,${{steps.version_check.outputs.releaseVersion}}"
 
 
   release-staging:
@@ -147,3 +155,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     
+      - name: Publish to Registry
+        uses: elgohr/Publish-Docker-Github-Action@master
+        with:
+          name: bytesonus/juno
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          tags: "${{steps.version_check.outputs.releaseVersion}}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM rust:latest as cargo-build
+
+RUN rustup target add x86_64-unknown-linux-musl
+
+WORKDIR /usr/src/juno
+
+COPY . .
+
+RUN cargo build --release --target=x86_64-unknown-linux-musl
+
+FROM alpine:latest
+
+RUN apk add --no-cache dumb-init
+
+WORKDIR /juno
+
+COPY --from=cargo-build /usr/src/juno/target/x86_64-unknown-linux-musl/release/juno .
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--", "/juno/juno"]
+
+# Use CMD TO Pass args
+


### PR DESCRIPTION
Arguments can be passed by directly including them in CMD. So if the image is called `juno`, something like:

`docker run juno -VVV --bind-addr 0.0.0.0 -p 1234`